### PR TITLE
Fix starport failed to serve due to multiple main package found

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,6 +11,7 @@ faucet:
   coins: ["100000000000nanolike"]
 build:
   binary: "liked"
+  main: cmd/liked
 init:
   home: "$HOME/.liked"
 genesis:


### PR DESCRIPTION
Ref oursky/likecoin-chain#122

Got this error: specify the path to your chain's main package in your config.yml>build.main: multiple main packages found