### PR TITLE
Fix starport app serve throws could not find app.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ LikeCoin chain is a blockchain built on the Cosmos SDK. Project page: https://li
 
 ## For development.
 
-LikeCoin chain support starport. Please follow the instruction on [starport](https://docs.starport.com/guide/install.html)
+LikeCoin chain support ignite cli (previously called starport). Please follow instructions to install [here](https://docs.ignite.com/guide/install.html)
 
 After installation, run
-`starport chain serve`
+`ignite chain serve`
 
 It will bring up the local dev chain with hot-reload.
 

--- a/app/app.go
+++ b/app/app.go
@@ -555,6 +555,10 @@ func (app *LikeApp) registerUpgradeHandlers() {
 	}
 }
 
+func (app *LikeApp) Name() string {
+	return app.BaseApp.Name()
+}
+
 // application updates every begin block
 func (app *LikeApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 	return app.mm.BeginBlock(ctx, req)


### PR DESCRIPTION
Ref oursky/likecoin-chain#220

Add missing interface used by starport to search for app impl

Testing done:
- Tested issue resolved in starport v0.19.5
- Tested issue resolved in ignite cli v0.20.4 (they renamed starport along with the tendermint org recently)