### PR TITLE
🚚 Rename go package to likecoin/likecoin-chain/v2

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -91,14 +91,14 @@ import (
 	ibchost "github.com/cosmos/ibc-go/v2/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/v2/modules/core/keeper"
 
-	"github.com/likecoin/likechain/x/iscn"
-	iscnkeeper "github.com/likecoin/likechain/x/iscn/keeper"
-	iscntypes "github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn"
+	iscnkeeper "github.com/likecoin/likecoin-chain/v2/x/iscn/keeper"
+	iscntypes "github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 
-	bech32authmigration "github.com/likecoin/likechain/bech32-migration/auth"
-	bech32govmigration "github.com/likecoin/likechain/bech32-migration/gov"
-	bech32slashingmigration "github.com/likecoin/likechain/bech32-migration/slashing"
-	bech32stakingmigration "github.com/likecoin/likechain/bech32-migration/staking"
+	bech32authmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/auth"
+	bech32govmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/gov"
+	bech32slashingmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/slashing"
+	bech32stakingmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/staking"
 )
 
 var (

--- a/bech32-migration/auth/auth.go
+++ b/bech32-migration/auth/auth.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 
-	"github.com/likecoin/likechain/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {

--- a/bech32-migration/gov/gov.go
+++ b/bech32-migration/gov/gov.go
@@ -8,7 +8,7 @@ import (
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/likecoin/likechain/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {

--- a/bech32-migration/slashing/slashing.go
+++ b/bech32-migration/slashing/slashing.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 
-	"github.com/likecoin/likechain/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {

--- a/bech32-migration/staking/staking.go
+++ b/bech32-migration/staking/staking.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/likecoin/likechain/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
 )
 
 func MigrateAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) {

--- a/bech32-migration/test/migrate.go
+++ b/bech32-migration/test/migrate.go
@@ -10,19 +10,19 @@ import (
 	"github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
-	"github.com/likecoin/likechain/testutil"
+	"github.com/likecoin/likecoin-chain/v2/testutil"
 
-	bech32migrationtestutil "github.com/likecoin/likechain/bech32-migration/testutil"
+	bech32migrationtestutil "github.com/likecoin/likecoin-chain/v2/bech32-migration/testutil"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	bech32authmigration "github.com/likecoin/likechain/bech32-migration/auth"
-	bech32govmigration "github.com/likecoin/likechain/bech32-migration/gov"
-	bech32slashingmigration "github.com/likecoin/likechain/bech32-migration/slashing"
-	bech32stakingmigration "github.com/likecoin/likechain/bech32-migration/staking"
+	bech32authmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/auth"
+	bech32govmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/gov"
+	bech32slashingmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/slashing"
+	bech32stakingmigration "github.com/likecoin/likecoin-chain/v2/bech32-migration/staking"
 )
 
 type MTAppOptions struct{}

--- a/bech32-migration/testutil/auth.go
+++ b/bech32-migration/testutil/auth.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 
-	"github.com/likecoin/likechain/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
 )
 
 func AssertAuthAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {

--- a/bech32-migration/testutil/gov.go
+++ b/bech32-migration/testutil/gov.go
@@ -10,7 +10,7 @@ import (
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/likecoin/likechain/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
 )
 
 func AssertGovAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {

--- a/bech32-migration/testutil/slashing.go
+++ b/bech32-migration/testutil/slashing.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 
-	"github.com/likecoin/likechain/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
 )
 
 func AssertSlashingAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {

--- a/bech32-migration/testutil/staking.go
+++ b/bech32-migration/testutil/staking.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 
-	"github.com/likecoin/likechain/bech32-migration/utils"
+	"github.com/likecoin/likecoin-chain/v2/bech32-migration/utils"
 )
 
 func AssertStakingAddressBech32(ctx sdk.Context, storeKey sdk.StoreKey, cdc codec.BinaryCodec) bool {

--- a/cmd/liked/cmd/cmd.go
+++ b/cmd/liked/cmd/cmd.go
@@ -14,7 +14,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
 
-	"github.com/likecoin/likechain/app"
+	"github.com/likecoin/likecoin-chain/v2/app"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -44,7 +44,7 @@ import (
 
 	simappcli "github.com/cosmos/cosmos-sdk/simapp/simd/cmd"
 
-	"github.com/likecoin/likechain/ip"
+	"github.com/likecoin/likecoin-chain/v2/ip"
 
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 )

--- a/cmd/liked/main.go
+++ b/cmd/liked/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/likecoin/likechain/cmd/liked/cmd"
+import "github.com/likecoin/likecoin-chain/v2/cmd/liked/cmd"
 
 func main() {
 	cmd.Execute()

--- a/dual_prefix_tests/bank_test.go
+++ b/dual_prefix_tests/bank_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/likecoin/likechain/testutil"
+	"github.com/likecoin/likecoin-chain/v2/testutil"
 	"github.com/stretchr/testify/require"
 
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"

--- a/dual_prefix_tests/iscn_test.go
+++ b/dual_prefix_tests/iscn_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/likecoin/likechain/testutil"
-	iscntypes "github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/testutil"
+	iscntypes "github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 	"github.com/stretchr/testify/require"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/likecoin/likechain
+module github.com/likecoin/likecoin-chain/v2
 
 go 1.18
 

--- a/ibc_tests/transfer_test.go
+++ b/ibc_tests/transfer_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	likeapp "github.com/likecoin/likechain/app"
+	likeapp "github.com/likecoin/likecoin-chain/v2/app"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/tendermint/tendermint/libs/log"

--- a/proto/iscn/genesis.proto
+++ b/proto/iscn/genesis.proto
@@ -4,7 +4,7 @@ package likechain.iscn;
 import "gogoproto/gogo.proto";
 import "iscn/params.proto";
 
-option go_package = "github.com/likecoin/likechain/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
 
 message GenesisState {
   message ContentIdRecord {

--- a/proto/iscn/iscnid.proto
+++ b/proto/iscn/iscnid.proto
@@ -3,7 +3,7 @@ package likechain.iscn;
 
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/likecoin/likechain/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
 
 message IscnIdPrefix {
   option (gogoproto.equal)            = true;

--- a/proto/iscn/params.proto
+++ b/proto/iscn/params.proto
@@ -4,7 +4,7 @@ package likechain.iscn;
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
-option go_package = "github.com/likecoin/likechain/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
 
 message Params {
   option (gogoproto.equal)            = false;

--- a/proto/iscn/query.proto
+++ b/proto/iscn/query.proto
@@ -5,7 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "iscn/params.proto";
 
-option go_package = "github.com/likecoin/likechain/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
 
 service Query {
   // Usage:

--- a/proto/iscn/store.proto
+++ b/proto/iscn/store.proto
@@ -4,7 +4,7 @@ package likechain.iscn;
 import "gogoproto/gogo.proto";
 import "iscn/iscnid.proto";
 
-option go_package = "github.com/likecoin/likechain/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
 
 message StoreRecord {
   IscnId iscn_id = 1 [

--- a/proto/iscn/tx.proto
+++ b/proto/iscn/tx.proto
@@ -3,7 +3,7 @@ package likechain.iscn;
 
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/likecoin/likechain/x/iscn/types";
+option go_package = "github.com/likecoin/likecoin-chain/v2/x/iscn/types";
 
 // Msg defines the bank Msg service.
 service Msg {

--- a/scripts/gen_proto.sh
+++ b/scripts/gen_proto.sh
@@ -28,7 +28,7 @@ for module in "${MODULES[@]}"; do
       --swagger_out ${SWAGGER_DIR} \
       --swagger_opt logtostderr=true --swagger_opt fqn_for_swagger_name=true --swagger_opt simple_operation_ids=true
 
-    mv github.com/likecoin/likechain/x/${module}/types/* x/${module}/types/
+    mv github.com/likecoin/likecoin-chain/v2/x/${module}/types/* x/${module}/types/
 done
 
 popd > /dev/null 2>&1

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -17,7 +17,7 @@ import (
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	tmdb "github.com/tendermint/tm-db"
 
-	"github.com/likecoin/likechain/app"
+	"github.com/likecoin/likecoin-chain/v2/app"
 )
 
 type (

--- a/testutil/testing_app.go
+++ b/testutil/testing_app.go
@@ -23,9 +23,9 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 
-	likeapp "github.com/likecoin/likechain/app"
+	likeapp "github.com/likecoin/likecoin-chain/v2/app"
 
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 )
 
 const DefaultNodeHome = "/tmp/.liked-test"

--- a/x/iscn/app_test.go
+++ b/x/iscn/app_test.go
@@ -15,10 +15,10 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
 
-	"github.com/likecoin/likechain/x/iscn/keeper"
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/keeper"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 
-	testutil "github.com/likecoin/likechain/testutil"
+	testutil "github.com/likecoin/likecoin-chain/v2/testutil"
 )
 
 var (

--- a/x/iscn/client/cli/query.go
+++ b/x/iscn/client/cli/query.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/version"
 
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 )
 
 const (

--- a/x/iscn/client/cli/tx.go
+++ b/x/iscn/client/cli/tx.go
@@ -14,7 +14,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
 
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 )
 
 func NewTxCmd() *cobra.Command {

--- a/x/iscn/handler.go
+++ b/x/iscn/handler.go
@@ -4,8 +4,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/likecoin/likechain/x/iscn/keeper"
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/keeper"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 )
 
 func NewHandler(k keeper.Keeper) sdk.Handler {

--- a/x/iscn/keeper/alias.go
+++ b/x/iscn/keeper/alias.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 )
 
 type (

--- a/x/iscn/keeper/genesis.go
+++ b/x/iscn/keeper/genesis.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 )
 
 func (k Keeper) InitGenesis(ctx sdk.Context, genesis *types.GenesisState) {

--- a/x/iscn/keeper/grpc_query.go
+++ b/x/iscn/keeper/grpc_query.go
@@ -8,7 +8,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 )
 
 const FingerprintRecordsPageLimit = 100

--- a/x/iscn/keeper/invariants.go
+++ b/x/iscn/keeper/invariants.go
@@ -13,7 +13,7 @@ import (
 
 	gocid "github.com/ipfs/go-cid"
 
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 )
 
 const (

--- a/x/iscn/keeper/keeper.go
+++ b/x/iscn/keeper/keeper.go
@@ -11,7 +11,7 @@ import (
 	authTypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	paramTypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 )
 
 type AccountKeeper interface {

--- a/x/iscn/keeper/msg_server.go
+++ b/x/iscn/keeper/msg_server.go
@@ -6,7 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 )
 
 type msgServer struct {

--- a/x/iscn/module.go
+++ b/x/iscn/module.go
@@ -16,9 +16,9 @@ import (
 	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	"github.com/likecoin/likechain/x/iscn/client/cli"
-	"github.com/likecoin/likechain/x/iscn/keeper"
-	"github.com/likecoin/likechain/x/iscn/types"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/client/cli"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/keeper"
+	"github.com/likecoin/likecoin-chain/v2/x/iscn/types"
 )
 
 var (


### PR DESCRIPTION
for version >=2.0.0, go requires suffix `v2` if we want to release go packages for other app to use
we should increment this suffix for `v3` `v4` etc from now on

this PR also rename the package to `likecoin-chain` instead of the old name `likechain`