### PR TITLE
Further hotfix on panic when unbonding unbonded validator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 // point sdk to fork and follow replaces at https://github.com/cosmos/cosmos-sdk/blob/v0.44.8/go.mod
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-	github.com/cosmos/cosmos-sdk => github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-2
+	github.com/cosmos/cosmos-sdk => github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-3
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 // point sdk to fork and follow replaces at https://github.com/cosmos/cosmos-sdk/blob/v0.44.8/go.mod
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-	github.com/cosmos/cosmos-sdk => github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-1
+	github.com/cosmos/cosmos-sdk => github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-2
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2

--- a/go.sum
+++ b/go.sum
@@ -610,8 +610,8 @@ github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOS
 github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-1 h1:j6oPbp/pf6Rwk5mwwZF8M1GLo5V8LfHlJPS1On0pqJQ=
-github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-1/go.mod h1:xkaQHdLk55zxd1C2sR6dKh53QVoBW0IWFsKv3nQKwtY=
+github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-2 h1:mldPKZSzuHJQ+Na+OiZuR2+neMMLCytjgqFPOPD8yew=
+github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-2/go.mod h1:xkaQHdLk55zxd1C2sR6dKh53QVoBW0IWFsKv3nQKwtY=
 github.com/lucasjones/reggen v0.0.0-20180717132126-cdb49ff09d77/go.mod h1:5ELEyG+X8f+meRWHuqUOewBOhvHkl7M76pdGEansxW4=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/go.sum
+++ b/go.sum
@@ -610,8 +610,8 @@ github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOS
 github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-2 h1:mldPKZSzuHJQ+Na+OiZuR2+neMMLCytjgqFPOPD8yew=
-github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-2/go.mod h1:xkaQHdLk55zxd1C2sR6dKh53QVoBW0IWFsKv3nQKwtY=
+github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-3 h1:hDeHrHYBJqEXhaSXYXB1AIBdGtJBLsdqB0gkpCueGlk=
+github.com/likecoin/cosmos-sdk v0.44.8-dual-prefix-hotfix-3/go.mod h1:xkaQHdLk55zxd1C2sR6dKh53QVoBW0IWFsKv3nQKwtY=
 github.com/lucasjones/reggen v0.0.0-20180717132126-cdb49ff09d77/go.mod h1:5ELEyG+X8f+meRWHuqUOewBOhvHkl7M76pdGEansxW4=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=


### PR DESCRIPTION
Also guard the case of validator not found (since it could be already removed in previous unbonding).
Also add comments.

Related SDK commit: https://github.com/likecoin/cosmos-sdk/commit/6cd3d089f47487caf72e8a9f18a9ceda93ce3675

The cause of the problem:

1. a validator (`cosmos1abcd...`) was unbonding before Bech32 address prefix migration
2. after prefix migration, the validator was further jailed
3. the SDK code tries to remove the old unbonding entry and insert a new one
4. however, since the validator address for the unbonding entry was stored in string format, and the code for removing the unbonding entry is searching for the new Bech32 prefix address, the old entry was not removed
5. so there are 2 unbonding entries for the same validator
6. the first unbonding entry triggers, turning the validator status to unbonded
7. the second unbonding entry triggers, and found that the validator was already unbonded, so the SDK code panic

Currently we are guarding the unbonding code so it won't panic if validator was already unbonded or removed, but leave an error log instead.