### PR TITLE
✨ Setup upgrade handler for v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+- Fix missing upgrade handler for 4.1.x upgrade
 
 ## [v4.1.0](https://github.com/likecoin/likecoin-chain/releases/v4.1.0)
 - Upgrade cosmovisor included in docker image to 1.5.0

--- a/app/app.go
+++ b/app/app.go
@@ -111,7 +111,7 @@ import (
 )
 
 const (
-	UpgradeName = "v4.0.0"
+	UpgradeName = "v4.1.1"
 )
 
 var (
@@ -344,7 +344,6 @@ func NewLikeApp(
 		skipUpgradeHeights, keys[upgradetypes.StoreKey], appCodec, homePath,
 		app.BaseApp, authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
-	app.setupUpgradeStoreLoaders()
 	app.registerUpgradeHandlers()
 	app.IscnKeeper = iscnkeeper.NewKeeper(appCodec, keys[iscntypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, iscnSubspace)
 
@@ -571,19 +570,6 @@ func (app *LikeApp) registerUpgradeHandlers() {
 	app.UpgradeKeeper.SetUpgradeHandler(UpgradeName, func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		return app.mm.RunMigrations(ctx, app.configurator, fromVM)
 	})
-}
-
-func (app *LikeApp) setupUpgradeStoreLoaders() {
-	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
-	if err != nil {
-		panic(err)
-	}
-	if upgradeInfo.Name == UpgradeName && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
-		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{"group"},
-		}
-		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
-	}
 }
 
 func (app *LikeApp) Name() string {


### PR DESCRIPTION
ibc v6 requires a chain upgrade
Since I forget to change the upgrade handler in 4.1.0, the expected upgrade name would thus be at least 4.1.1